### PR TITLE
Fix scoreboard widths

### DIFF
--- a/pelican/content/simulator/binary_life.html
+++ b/pelican/content/simulator/binary_life.html
@@ -39,11 +39,11 @@
               <ul class="list-group scoreboard-panel list-group-flush">
   
                   <li class="list-group-item scoreboard-panel" id="scoreboard-panel-livecells1">
-                      <table width="100%"><tr><td>
+                      <table width="100%"><tr><td class="scoreboard-table-left-column">
                         <span class="badge badge-success" id="team1winner"></span>
                         <span class="badge badge-danger" id="team1loser"></span>
                         <span class="team1color team1name"></span>
-                      </td><td align="right">
+                      </td><td align="right" class="scoreboard-table-right-column">
                         <b>
                         <span class="team1color" id="livecells1"></span>
                         </b>
@@ -51,11 +51,11 @@
                   </li>
   
                   <li class="list-group-item scoreboard-panel" id="scoreboard-panel-livecells2">
-                      <table width="100%"><tr><td>
+                      <table width="100%"><tr><td class="scoreboard-table-left-column">
                         <span class="badge badge-success" id="team2winner"></span>
                         <span class="badge badge-danger" id="team2loser"></span>
                         <span class="team2color team2name"></span>
-                      </td><td align="right">
+                      </td><td align="right" class="scoreboard-table-right-column">
                         <b>
                         <span class="team2color" id="livecells2"></span>
                         </b>


### PR DESCRIPTION
During the Golly World Series (Season 1) we noticed some problems with the San Francisco Boat Shoes team name having its width changed by the score (changing btwn double and triple digits) for certain view widths.

This fixes the scoreboard to be a fixed width by adding classes to the table columns. Corresponding fix TBA to golly-splorts/golly-pelican-theme